### PR TITLE
try to fix doc test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 //! // We use a barrier to ensure the readout happens after all writing
 //! let barrier = Arc::new(Barrier::new(numthreads + 1));
 //!
-//! for _ in range(0, numthreads)
+//! for _ in (0..numthreads)
 //! {
 //!     let my_barrier = barrier.clone();
 //!     let my_lock = spinlock.clone();
@@ -67,7 +67,7 @@
 //!         // Release the lock to prevent a deadlock
 //!         drop(guard);
 //!         my_barrier.wait();
-//!     }).detach();
+//!     });
 //! }
 //!
 //! barrier.wait();


### PR DESCRIPTION
- `range(...)` was replaced by range syntax
- `Thread::spawn(...)` spawns a detached thread now (and has no `detach()` method anymore).

It still panics on my machine (with `thread '_1' panicked at 'Box<Any>', /home/rustbuild/src/rust-buildbot/slave/nightly-dist-rustc-linux/build/src/libsyntax/diagnostic.rs:144`) and throws an error about std being unstable, but the two changes should be alright...