### PR TITLE
Swap the members of the Mutex struct

### DIFF
--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -78,8 +78,8 @@ use util::cpu_relax;
 /// ```
 pub struct Mutex<T>
 {
-    lock: AtomicBool,
     data: UnsafeCell<T>,
+    lock: AtomicBool,
 }
 
 /// A guard to which the protected data can be accessed

--- a/src/mutex.rs
+++ b/src/mutex.rs
@@ -87,8 +87,8 @@ pub struct Mutex<T>
 /// When the guard falls out of scope it will release the lock.
 pub struct MutexGuard<'a, T:'a>
 {
-    lock: &'a AtomicBool,
     data: &'a mut T,
+    lock: &'a AtomicBool,
 }
 
 unsafe impl<T> Sync for Mutex<T> {}

--- a/src/rw_lock.rs
+++ b/src/rw_lock.rs
@@ -33,8 +33,8 @@ pub struct RwLock<T>
 /// potentially releasing the lock.
 pub struct RwLockReadGuard<'a, T:'a>
 {
-    lock: &'a AtomicUsize,
     data: &'a T,
+    lock: &'a AtomicUsize,
 }
 
 /// A guard to which the protected data can be written
@@ -42,8 +42,8 @@ pub struct RwLockReadGuard<'a, T:'a>
 /// When the guard falls out of scope it will release the lock.
 pub struct RwLockWriteGuard<'a, T:'a>
 {
-    lock: &'a AtomicUsize,
     data: &'a mut T,
+    lock: &'a AtomicUsize,
 }
 
 unsafe impl<T> Sync for RwLock<T> {}

--- a/src/rw_lock.rs
+++ b/src/rw_lock.rs
@@ -23,8 +23,8 @@ use util::cpu_relax;
 ///
 pub struct RwLock<T>
 {
-    lock: AtomicUsize,
     data: UnsafeCell<T>,
+    lock: AtomicUsize,
 }
 
 /// A guard to which the protected data can be read


### PR DESCRIPTION
This means that a reference to the mutex behaves the same as a reference to the contents, which is useful in cases like the x86 interrupt descriptor table where a pointer needs to be stored in another structure.

If you think this deserves a version bump let me know and I'll oblige.